### PR TITLE
Allow space after async keyword in arrow functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ---
 
+## [0.2.1] – 2019-06-30
+### Fixed
+* [#21] Allow space after `async` keyword in arrow functions.
+
 ## [0.2.0] – 2019-06-29
 ### Added
 * [#1] Official support for Node 10.
@@ -32,5 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 [#16]: https://github.com/Comandeer/eslint-config/issues/16
 [#17]: https://github.com/Comandeer/eslint-config/issues/17
 [#18]: https://github.com/Comandeer/eslint-config/issues/18
+[#21]: https://github.com/Comandeer/eslint-config/issues/21
 
+[0.2.1]: https://github.com/Comandeer/rollup-plugin-babel-minify/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/Comandeer/rollup-plugin-babel-minify/compare/v0.1.0...v0.2.0

--- a/index.js
+++ b/index.js
@@ -137,7 +137,11 @@ module.exports = {
 		'require-await': 'error',
 		'require-yield': 'error',
 		semi: [ 'error', 'always' ],
-		'space-before-function-paren': [ 'error', 'never' ],
+		'space-before-function-paren': [ 'error', {
+			anonymous: 'never',
+			named: 'never',
+			asyncArrow: 'always'
+		} ],
 		'space-in-parens': [ 'error', 'always' ],
 		'space-infix-ops': 'error',
 		'space-unary-ops': 'error',

--- a/tests/fixtures/asyncArrow.js
+++ b/tests/fixtures/asyncArrow.js
@@ -1,0 +1,3 @@
+const test = async () => {};
+
+test();

--- a/tests/index.js
+++ b/tests/index.js
@@ -21,4 +21,13 @@ describe( 'eslint-config', () => {
 
 		expect( errors ).to.have.lengthOf( 0 );
 	} );
+
+	// #21
+	it( 'allows space after async keyword in arrow functions', () => {
+		const cli = new CLIEngine( config );
+		const report = cli.executeOnFiles( [ `${ __dirname }/fixtures/asyncArrow.js` ] );
+		const errors = CLIEngine.getErrorResults( report.results );
+
+		expect( errors ).to.have.lengthOf( 0 );
+	} );
 } );


### PR DESCRIPTION
Closes #21.